### PR TITLE
use https

### DIFF
--- a/view/static/testmap.html
+++ b/view/static/testmap.html
@@ -307,14 +307,14 @@ textarea {
 	}
 
 
-   var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+   var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            osmAttrib = '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, { maxZoom: 18, attribution: osmAttrib }),
             mymap,
             drawnItems = L.featureGroup().addTo(mymap);
    L.control.layers({
         'osm': osm.addTo(mymap),
-        "google": L.tileLayer('http://www.google.cn/maps/vt?lyrs=s@189&gl=cn&x={x}&y={y}&z={z}', {
+        "google": L.tileLayer('https://www.google.cn/maps/vt?lyrs=s@189&gl=cn&x={x}&y={y}&z={z}', {
             attribution: 'google'
         })
      }, 


### PR DESCRIPTION
Map uses http assets. When serving via a https, browsers throw up mixed content errors. This PR introduces minor fixes.